### PR TITLE
Fix compilation for Windows

### DIFF
--- a/lib/stm32cubemx_init/Src/main.c
+++ b/lib/stm32cubemx_init/Src/main.c
@@ -44,7 +44,7 @@
 #include "gpio.h"
 
 /* USER CODE BEGIN Includes */
-#include "../../src/app.h"
+#include "../../../src/app.h"
 /* USER CODE END Includes */
 
 /* Private variables ---------------------------------------------------------*/

--- a/lib/stm32cubemx_init/library.json
+++ b/lib/stm32cubemx_init/library.json
@@ -1,12 +1,9 @@
 {
   "name": "stm32cubemx_init",
   "description": "STM32CubeMX generated files",
+  "frameworks": ["stm32cube"],
   "build": {
-    "srcFilter": [
-      "+<Src>",
-      "+<Inc>",
-      "-<Src/system_stm32*.c>"
-    ],
+    "srcFilter": "+<*.c>, -<system_stm32*.c>",
     "flags": [
       "-I Inc"
     ]


### PR DESCRIPTION
* srcFilter path have to be relative to the source directory, apparently ([ref](https://community.platformio.org/t/pio-does-not-compile-all-included-library-classes-which-leads-to-linker-errors/1034/8).
* Add ing"Inc" to the srcFilter does nothing, there are no .c files there.
* also corrected an include path for App.h. A cleaner way would be to put this header into the `include/` folder of the project.